### PR TITLE
Fix compatibility with Ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.0
-before_install: gem install bundler -v 1.15.0
+  - 3.0.1
+before_install: gem install bundler -v 2.2.16
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/lib/active_model_validates_intersection_of/validator.rb
+++ b/lib/active_model_validates_intersection_of/validator.rb
@@ -13,7 +13,7 @@ module ActiveModelValidatesIntersectionOf
       raise ArgumentError, "value must be an array" unless value.is_a?(Array)
       
       if (value - members(record)).any?
-        record.errors.add(attribute, :inclusion, options.except(:in, :within).merge!(value: value))
+        record.errors.add(attribute, :inclusion, **options.except(:in, :within).merge!(value: value))
       end
     end
 


### PR DESCRIPTION
Ruby 3.0 makes it necessary to explicitly convert a hash to keyword parameters.
Details: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

I additionally added the Ruby version to the travis config und updated the bundler version, hope this helps!